### PR TITLE
Fixes Inconsistent URL Replace Handing Due to Missing Slashes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,7 +107,7 @@ module.exports = function (grunt) {
 				options: {
 					prefix: "const VERSION = '"
 				},
-				src: ['<%= pkg.name %>.php']
+				src: ['<%= pkg.name %>.php', 'class-<%= pkg.name %>.php']
 			},
 			header: {
 				options: {
@@ -120,7 +120,14 @@ module.exports = function (grunt) {
 					prefix: 'Stable tag:\\s+'
 				},
 				src: ['readme.txt']
-			}
+			},
+			php: {
+				options: {
+					prefix: '@since\\s*',
+					replace: '0\.0\.0'
+				},
+				src: ['*.php']
+			},
 		}
 
 	});

--- a/class-wp-local-media-proxy.php
+++ b/class-wp-local-media-proxy.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Main plugin class.
+ *
+ * @package  Ndigitals_Wp_Local_Media_Proxy_MuPlugin
+ *
+ * @link https://gist.github.com/kingkool68/d5e483528a260e5c7921afb5c88bffd6
+ */
+
+namespace Ndigitals\MuPlugin;
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Wp_Local_Media_Proxy class.
+ * Defines plugin functionality.
+ *
+ * @package Ndigitals_Wp_Local_Media_Proxy_MuPlugin
+ */
+class Wp_Local_Media_Proxy {
+
+	/**
+	 * Plugin version, used for cache-busting of style and script file references.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var string
+	 */
+	const VERSION = '1.1.0';
+
+	/**
+	 * Instance of this class.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var Wp_Local_Media_Proxy
+	 */
+	protected static $_instance = null;
+
+	/**
+	 * The home URL of the site to use for images/media. Default: ''.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var string
+	 */
+	protected $home_url = '';
+
+	/**
+	 * The URL of the remote site to use for images/media. Default: ''.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var string
+	 */
+	protected $remote_medial_url = '';
+
+	/**
+	 * The WordPress uploads directory path. Default: ''.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var string
+	 */
+	protected $wp_upload_base_dir = '';
+
+	/**
+	 * The WordPress uploads directory URL. Default: ''.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var string
+	 */
+	protected $wp_upload_base_url = '';
+
+	/**
+	 * Initialize the plugin by setting localization and loading public scripts,
+	 * styles, filters, and hooks.
+	 *
+	 * @since 1.1.0
+	 */
+	private function __construct() {
+
+		// Make sure the home URL contains a trailing slash for consistent find/replace actions.
+		$this->home_url = trailingslashit( get_home_url() );
+
+		// Check for remote media URL and set the class property.
+		// Example Configuration "LOCALDEV_USE_REMOTE_MEDIA_URL=https://example.com".
+		if ( defined( 'LOCALDEV_USE_REMOTE_MEDIA_URL' ) && ! empty( constant( 'LOCALDEV_USE_REMOTE_MEDIA_URL' ) ) ) {
+			// Make sure the remote URL contains a trailing slash for consistent find/replace actions.
+			$this->remote_medial_url = trailingslashit( LOCALDEV_USE_REMOTE_MEDIA_URL );
+		}
+
+		// Store the WordPress uploads directory path & URL for image/media replacements.
+		$wp_upload_dir            = wp_upload_dir();
+		$this->wp_upload_base_dir = $wp_upload_dir['basedir'];
+		$this->wp_upload_base_url = $wp_upload_dir['baseurl'];
+
+		// Register hooks.
+		$this->register_hooks();
+
+	}
+
+	/**
+	 * Return an instance of this class.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return Wp_Local_Media_Proxy    A single instance of this class.
+	 */
+	public static function get_instance() {
+
+		// If the single instance hasn't been set, set it now.
+		if ( null === self::$_instance ) {
+			self::$_instance = new self();
+		}
+
+		return self::$_instance;
+	}
+
+	/**
+	 * Register any required hooks for MU Plugin functionality.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return void
+	 */
+	private function register_hooks() {
+
+		// Check for remote media URL and add hooks to proxy media library images.
+		if ( ! empty( $this->remote_medial_url ) ) {
+			// Add filters only if constant is configured.
+			add_filter( 'wp_get_attachment_image_src', array( $this, 'filter_wp_get_attachment_image_src' ) );
+			add_filter( 'wp_calculate_image_srcset', array( $this, 'filter_wp_calculate_image_srcset' ) );
+			add_filter( 'wp_get_attachment_url', array( $this, 'filter_wp_get_attachment_url' ) );
+		}
+
+	}
+
+	/**
+	 * Check for a local media file and if it doesn't exist replace the home URL with the remote URL.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $image_url The URL of the image/media file.
+	 *
+	 * @return string
+	 */
+	private function replace_url( $image_url ) {
+
+		$absolute_path = str_replace( $this->wp_upload_base_url, $this->wp_upload_base_dir, $image_url );
+
+		if ( file_exists( $absolute_path ) ) {
+			return $image_url;
+		}
+
+		$image_url = str_replace( $this->home_url, $this->remote_medial_url, $image_url );
+
+		return $image_url;
+
+	}
+
+	/**
+	 * Proxy requests for images to a remote URL.
+	 *
+	 * @link https://developer.wordpress.org/reference/hooks/wp_get_attachment_image_src/
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array|boolean $image Array of image data, or boolean false if no image is available.
+	 *
+	 * @return array|boolean
+	 */
+	public function filter_wp_get_attachment_image_src( $image = array() ) {
+
+		if ( ! is_array( $image ) || empty( $image ) ) {
+			return $image;
+		}
+
+		$image[0] = $this->replace_url( $image[0] );
+
+		return $image;
+
+	}
+
+	/**
+	 * Proxy srcset requests to a remote URL.
+	 *
+	 * @link https://developer.wordpress.org/reference/hooks/wp_calculate_image_srcset/
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array $sources One or more arrays of source data to include in the 'srcset'.
+	 *
+	 * @return array
+	 */
+	public function filter_wp_calculate_image_srcset( $sources = array() ) {
+
+		if ( is_array( $sources ) && ! is_admin() ) {
+			foreach ( $sources as $key => $val ) {
+				$val['url']  = $this->replace_url( $val['url'] );
+				$sources[ $key ] = $val;
+			}
+		}
+
+		return $sources;
+
+	}
+
+	/**
+	 * Proxy the attachement URL to a remote site.
+	 *
+	 * @link https://developer.wordpress.org/reference/hooks/wp_get_attachment_url/
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $url URL for the given attachment.
+	 *
+	 * @return string
+	 */
+	public function filter_wp_get_attachment_url( $url = '' ) {
+
+		if ( empty( $url ) ) {
+			return $url;
+		}
+
+		return $this->replace_url( $url );
+
+	}
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-local-media-proxy",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-local-media-proxy",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"description": "Proxy images on a local development WordPress site from a remote server.",
 	"main": "Gruntfile.js",
 	"repository": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -71,7 +71,7 @@
 		 Multiple valid text domains can be provided as a comma-delimited list. -->
   <rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="oidc-generic-button-text-addon" />
+			<property name="text_domain" type="array" value="wp-local-media-proxy" />
 		</properties>
   </rule>
 

--- a/wp-local-media-proxy.php
+++ b/wp-local-media-proxy.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Local Development Media Library Proxy
  * Description: Provides the ability to proxy media library requests to a remote site for local development.
- * Version: 1.0.4
+ * Version: 1.1.0
  * Author: Tim Nolte
  * Author URI: https://www.ndigitals.com
  *
@@ -16,103 +16,69 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-// Check for remote media URL and add hooks to proxy media library images.
-// Example Configuration "DDEV_USE_REMOTE_MEDIA_URL=https://example.com".
-if ( defined( 'LOCALDEV_USE_REMOTE_MEDIA_URL' ) && ! empty( constant( 'LOCALDEV_USE_REMOTE_MEDIA_URL' ) ) ) {
-	add_filter( 'wp_get_attachment_image_src', 'wplmp_filter_wp_get_attachment_image_src' );
-	add_filter( 'wp_calculate_image_srcset', 'wplmp_filter_wp_calculate_image_srcset' );
-	add_filter( 'wp_get_attachment_url', 'wplmp_filter_wp_get_attachment_url' );
-}
-
 /**
- * Proxy requests for images to a remote URL.
- *
- * @link https://developer.wordpress.org/reference/hooks/wp_get_attachment_image_src/
- *
- * @param array|boolean $image Array of image data, or boolean false if no image is available.
- *
- * @return array|boolean
+ * Require public facing functionality
  */
-function wplmp_filter_wp_get_attachment_image_src( $image = array() ) {
+require_once( plugin_dir_path( __FILE__ ) . 'class-wp-local-media-proxy.php' );
 
-	if ( ! is_array( $image ) || empty( $image ) ) {
-		return $image;
+use Ndigitals\MuPlugin\Wp_Local_Media_Proxy;
+
+// Due to namespace usage and composer package requirements we require PHP >= 7.0.0.
+if ( ! defined( 'PHP_VERSION' ) || ! function_exists( 'version_compare' ) || version_compare( PHP_VERSION, '7.0.0', '<' ) ) {
+
+	// When plugin is used via the WP-CLI print out the text instead of expecting the WordPress Dashboard to be present.
+	if ( class_exists( 'WP_CLI' ) ) {
+
+		WP_CLI::warning( _wplmp_php_version_text() );
+
+	} else {
+
+		// Add Dashboard admin notice for plugin PHP version check failure.
+		add_action( 'admin_notices', '_wplmp_php_version_error' );
+
 	}
+} else {
 
-	$wp_upload_dir = wp_upload_dir();
-	$base_dir      = $wp_upload_dir['basedir'];
-	$base_url      = $wp_upload_dir['baseurl'];
-	$absolute_path = str_replace( $base_url, $base_dir, $image[0] );
-
-	if ( file_exists( $absolute_path ) ) {
-		return $image;
-	}
-
-	$find     = get_home_url();
-	$replace  = LOCALDEV_USE_REMOTE_MEDIA_URL;
-	$image[0] = str_replace( $find, $replace, $image[0] );
-
-	return $image;
+	// Startup the plugin to register hooks.
+	_wplmp_init();
 
 }
 
 /**
- * Proxy srcset requests to a remote URL.
+ * Admin notice for incompatible versions of PHP.
  *
- * @link https://developer.wordpress.org/reference/hooks/wp_calculate_image_srcset/
- *
- * @param array $sources One or more arrays of source data to include in the 'srcset'.
- *
- * @return array
+ * @since 1.1.0
  */
-function wplmp_filter_wp_calculate_image_srcset( $sources = array() ) {
+function _wplmp_php_version_error() {
 
-	if ( is_array( $sources ) && ! is_admin() ) {
-		$wp_upload_dir = wp_upload_dir();
-		$base_dir      = $wp_upload_dir['basedir'];
-		$base_url      = $wp_upload_dir['baseurl'];
-		$find          = get_home_url();
-		$replace       = LOCALDEV_USE_REMOTE_MEDIA_URL;
-		foreach ( $sources as $key => $val ) {
-			$absolute_path = str_replace( $base_url, $base_dir, $val['url'] );
-
-			if ( ! file_exists( $absolute_path ) ) {
-				$val['url']  = str_replace( $find, $replace, $val['url'] );
-				$sources[ $key ] = $val;
-			}
-		}
-	}
-
-	return $sources;
+	printf( '<div class="error"><p>%s</p></div>', esc_html( _wplmp_php_version_text() ) );
 
 }
 
 /**
- * Proxy the attachement URL to a remote site.
+ * String describing the minimum PHP version.
  *
- * @link https://developer.wordpress.org/reference/hooks/wp_get_attachment_url/
+ * @since 1.1.0
  *
- * @param string $url URL for the given attachment.
- *
- * @return string
+ * @return string The localized PHP version requirement message text.
  */
-function wplmp_filter_wp_get_attachment_url( $url = '' ) {
+function _wplmp_php_version_text() {
 
-	if ( is_admin() ) {
-		return $url;
-	}
+	return __( 'Local Media Proxy MU Plugin error: Your version of PHP is too old to run this MU Plugin. You must be running PHP 7.0 or higher.', 'wp-local-media-proxy' );
 
-	$wp_upload_dir = wp_upload_dir();
-	$base_dir      = $wp_upload_dir['basedir'];
-	$base_url      = $wp_upload_dir['baseurl'];
-	$find          = get_home_url();
-	$replace       = LOCALDEV_USE_REMOTE_MEDIA_URL;
-	$absolute_path = str_replace( $base_url, $base_dir, $url );
+}
 
-	if ( ! file_exists( $absolute_path ) ) {
-		$url = str_replace( $find, $replace, $url );
-	}
+/**
+ * Intializes the main plugin global instance.
+ *
+ * @since 1.1.0
+ *
+ * @return Ndigitals\MuPlugin\Wp_Local_Media_Proxy The single Ndigitals\MuPlugin\Wp_Local_Media_Proxy instance.
+ */
+function _wplmp_init() {
 
-	return $url;
+	$muplugin = Wp_Local_Media_Proxy::get_instance();
+
+	return $muplugin;
 
 }


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* Refactors MU Plugin to use a plugin class & OOP.
* Adds use of trailingslashit to URLs before find/replace use.
* Updates version bumping to handle setting `@since 0.0.0` references.
* Fixes text domain settings.
* Bumps the version number for the next release.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully tested with your changes locally?
